### PR TITLE
Enabled :minify argument to supply hash to uglifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Please read [Guard doc](https://github.com/guard/guard#readme) for more informat
 destination: 'public/js'          # change the destination folder in which the compiled assets are saved, default: 'public/javascripts'
 asset_paths: 'app/js'             # add a directory (or on array of directories) to Sprockets' environment's load path, default: ['app/assets/javascripts']
 asset_paths: ['app/js', 'lib/js'] # asset_paths can be a String or an Array
-minify: true                      # minify the JavaScript files content using Uglifier, default: false
-                                  # be sure to add: "gem 'uglifier'" in your Gemfile
+minify: true                 # minify the JavaScript files content using Uglifier. You can pass true, false, or an Uglifier options hash. default: false
+                                     # be sure to add: "gem 'uglifier'" in your Gemfile
 css_minify: true                  # minify the CSS files content using YUI Compressor, default: false
                                   # be sure to add: "gem 'yui-compressor'" in your Gemfile
 keep_paths: true                 # retain the directory structure of an asset's path relative to the asset_path, default: false

--- a/lib/guard/sprockets.rb
+++ b/lib/guard/sprockets.rb
@@ -22,10 +22,10 @@ module Guard
       @asset_paths.each { |p| @sprockets.append_path(p) }
       @root_file.each { |f| @sprockets.append_path(Pathname.new(f).dirname) }
 
-      if @options.delete(:minify)
+      if @options[:minify]
         begin
           require 'uglifier'
-          @sprockets.js_compressor = ::Uglifier.new
+          @sprockets.js_compressor = ::Uglifier.new(@options[:minify].is_a?(Hash) ? @options[:minify] : {})
           UI.info 'Sprockets will compress JavaScript output.'
         rescue LoadError => ex
           UI.error "minify: Uglifier cannot be loaded. No JavaScript compression will be used.\nPlease include 'uglifier' in your Gemfile."

--- a/spec/guard/sprockets_spec.rb
+++ b/spec/guard/sprockets_spec.rb
@@ -17,7 +17,9 @@ describe Guard::Sprockets do
 
       describe 'minify' do
         it { described_class.new.sprockets.js_compressor.should be_nil }
+        it { described_class.new(minify: false).sprockets.js_compressor.should be_nil }
         it { described_class.new(minify: true).sprockets.js_compressor.should_not be_nil }
+        it { described_class.new(minify: { mangle: false }).sprockets.js_compressor.should_not be_nil }
       end
 
       describe 'css_minify' do


### PR DESCRIPTION
Credit goes to @rapind for this one. :+1: 

I needed to customize the options being supplied to Uglifier. The pull request these changes were inspired is here: https://github.com/pferdefleisch/guard-sprockets/pull/12.

I think it would be good to rename the `minify` argument to `js_minify` at some point to be clear that it is only for JavaScript and not CSS.
