### PR TITLE
Renamed :minify option to :js_minify

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ Please read [Guard doc](https://github.com/guard/guard#readme) for more informat
 destination: 'public/js'          # change the destination folder in which the compiled assets are saved, default: 'public/javascripts'
 asset_paths: 'app/js'             # add a directory (or on array of directories) to Sprockets' environment's load path, default: ['app/assets/javascripts']
 asset_paths: ['app/js', 'lib/js'] # asset_paths can be a String or an Array
-minify: true                 # minify the JavaScript files content using Uglifier. You can pass true, false, or an Uglifier options hash. default: false
-                                     # be sure to add: "gem 'uglifier'" in your Gemfile
+js_minify: true                   # minify the JavaScript files content using Uglifier. You can pass true, false, or an Uglifier options hash. default: false
+                                  # be sure to add: "gem 'uglifier'" in your Gemfile
 css_minify: true                  # minify the CSS files content using YUI Compressor, default: false
                                   # be sure to add: "gem 'yui-compressor'" in your Gemfile
-keep_paths: true                 # retain the directory structure of an asset's path relative to the asset_path, default: false
-                                     # this prevents assets with the same basename, but placed different folders, from overwriting each other in the destination folder
-                                     # e.x. with this option set to true: app/js/vendor/rails/turbolinks.js.coffee -> public/js/vendor/rails/turbolinks.js
-                                     # and with this option set to false: app/js/vendor/rails/turbolinks.js.coffee -> public/js/turbolinks.js
-root_file: 'app/js/app.js'      # if set, only this file will be compiled, default: nil
-root_file: ['one.js', 'two.js'] # root_file can be a String or an Array
+keep_paths: true                  # retain the directory structure of an asset's path relative to the asset_path, default: false
+                                  # this prevents assets with the same basename, but placed different folders, from overwriting each other in the destination folder
+                                  # e.x. with this option set to true: app/js/vendor/rails/turbolinks.js.coffee -> public/js/vendor/rails/turbolinks.js
+                                  # and with this option set to false: app/js/vendor/rails/turbolinks.js.coffee -> public/js/turbolinks.js
+root_file: 'app/js/app.js'        # if set, only this file will be compiled, default: nil
+root_file: ['one.js', 'two.js']   # root_file can be a String or an Array
 ```
 
 ## Development

--- a/lib/guard/sprockets.rb
+++ b/lib/guard/sprockets.rb
@@ -22,13 +22,14 @@ module Guard
       @asset_paths.each { |p| @sprockets.append_path(p) }
       @root_file.each { |f| @sprockets.append_path(Pathname.new(f).dirname) }
 
-      if @options[:minify]
+      if js_minify_option = @options[:js_minify] || @options[:minify]
+        UI.warning 'DEPRECATION WARNING: The :minify option has been renamed to :js_minify. Please modify your Guardfile to use the :js_minify option instead.' if @options[:minify]
         begin
           require 'uglifier'
-          @sprockets.js_compressor = ::Uglifier.new(@options[:minify].is_a?(Hash) ? @options[:minify] : {})
+          @sprockets.js_compressor = ::Uglifier.new(js_minify_option.is_a?(Hash) ? js_minify_option : {})
           UI.info 'Sprockets will compress JavaScript output.'
         rescue LoadError => ex
-          UI.error "minify: Uglifier cannot be loaded. No JavaScript compression will be used.\nPlease include 'uglifier' in your Gemfile."
+          UI.error "js_minify: Uglifier cannot be loaded. No JavaScript compression will be used.\nPlease include 'uglifier' in your Gemfile."
           UI.debug ex.message
         end        
       end

--- a/spec/guard/sprockets_spec.rb
+++ b/spec/guard/sprockets_spec.rb
@@ -15,11 +15,11 @@ describe Guard::Sprockets do
         it { described_class.new(destination: 'foo/bar').destination.should eq 'foo/bar' }
       end
 
-      describe 'minify' do
+      describe 'js_minify' do
         it { described_class.new.sprockets.js_compressor.should be_nil }
-        it { described_class.new(minify: false).sprockets.js_compressor.should be_nil }
-        it { described_class.new(minify: true).sprockets.js_compressor.should_not be_nil }
-        it { described_class.new(minify: { mangle: false }).sprockets.js_compressor.should_not be_nil }
+        it { described_class.new(js_minify: false).sprockets.js_compressor.should be_nil }
+        it { described_class.new(js_minify: true).sprockets.js_compressor.should_not be_nil }
+        it { described_class.new(js_minify: { mangle: false }).sprockets.js_compressor.should_not be_nil }
       end
 
       describe 'css_minify' do


### PR DESCRIPTION
I've renamed the :minify option to :js_minify to be consistent with how :css_minify works. :minify still works for the time being, but has been deprecated.
